### PR TITLE
Add ability to post items and payments using stripe [part-1].

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 .env
+
+# Stripe
+stripe_backup_code.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - '10'
+  - '8'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+# Flipit Code of Conduct

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"passport-google-oauth20": "^2.0.0",
 		"passport-jwt": "^4.0.0",
 		"spdy": "^4.0.2",
+		"stripe": "^8.63.0",
 		"uuid": "^8.1.0"
 	},
 	"devDependencies": {

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -1,0 +1,122 @@
+const initializeQtyBtnsState = () => {
+	const inputEl = document.getElementById('quantity-input');
+	const maxQty = inputEl.getAttribute('max');
+	const addBtn = document.getElementById('add');
+	const subtractBtn = document.getElementById('subtract');
+	subtractBtn.disabled = true;
+	if(maxQty == 1) {
+		addBtn.disabled = true;
+	}
+}
+
+/* Method for changing the product quantity when a customer clicks the increment / decrement buttons */
+let updateQtyBtnsState = function (evt) {
+	if (evt && evt.type === 'keypress' && evt.keyCode !== 13) {
+	  return;
+	}
+  
+	const isAdding = evt && evt.target.id === 'add';
+	const inputEl = document.getElementById('quantity-input');
+	const submitBtn = document.getElementById('submit');
+	const addBtn = document.getElementById('add');
+	const subtractBtn = document.getElementById('subtract');
+	const maxQty = inputEl.getAttribute('max');	
+	
+	const currentQuantity = parseInt(inputEl.value);
+  
+	// Calculate new quantity
+	const quantity = evt
+	? isAdding
+	? currentQuantity + 1
+	: currentQuantity - 1
+	: currentQuantity;
+	
+	// Update number input with new value.
+	inputEl.value = quantity;
+
+	// Calculate the total amount and format it to show in the "Buy" button.
+	let amount = config.unitAmount;
+	let totalAmount = amount * quantity;
+	// Show total Amount in the buy button
+	submitBtn.innerHTML = `Buy for ${totalAmount}`;
+
+	// Disable quantity buttons if they reach their respective limit
+	if(quantity == maxQty) {
+		addBtn.disabled = true;
+	}
+	if(quantity == 1) {
+		subtractBtn.disabled = true;
+	}
+};
+  
+  /* Attach method */
+  Array.from(document.getElementsByClassName('increment-btn')).forEach(
+	(element) => {
+	  element.addEventListener('click', updateQtyBtnsState);
+	}
+  );
+  
+  /* Handle any errors returns from Checkout  */
+  let handleResult = function (result) {
+	  console.log('In handleResult, result = ', result);
+	if (result.error) {
+	  let displayError = document.getElementById('error-message');
+	  displayError.textContent = result.error.message;
+	}
+  };
+  
+  // Create a Checkout Session with the selected quantity
+  let createCheckoutSession = function (priceId) {
+	let inputEl = document.getElementById('quantity-input');
+	let quantity = parseInt(inputEl.value);
+	
+	return fetch('/v1/item/create-checkout-session', {
+	  method: 'POST',
+	  headers: {
+		'Content-Type': 'application/json',
+	  },
+	  body: JSON.stringify({
+		quantity: quantity,
+		priceId: priceId
+	  }),
+	})
+	.then(function (result) {
+	  	return result.json();
+	})
+	.catch(err => {
+		console.log("Err = ", err.message);
+		throw err;
+	})
+  };
+  
+
+  let containerEle = document.getElementsByClassName('container')[0];
+  let priceId = containerEle.getAttribute('id');
+  const url = `/v1/item/retrieve-price/${priceId}`;
+
+  /* Get your Stripe publishable key to initialize Stripe.js */
+  fetch(url)
+	.then(function (result) {
+	  return result.json();
+	})
+	.then(function (json) {
+	  window.config = json;
+	  let stripe = Stripe(config.publicKey);
+	  initializeQtyBtnsState();		// Initializes the quantity buttons state on checkout page
+	  
+	  // Setup event handler to create a Checkout Session on submit
+	  document.querySelector('#submit').addEventListener('click', function (evt) {
+		createCheckoutSession(priceId).then(function (data) {
+		  stripe
+			.redirectToCheckout({
+			  sessionId: data.sessionId,
+			})
+			.then(handleResult);
+		});
+	  });
+	})
+	.catch(err => {
+		console.log("throwing further...");
+		throw err;
+	})
+  

--- a/src/config/express.js
+++ b/src/config/express.js
@@ -42,6 +42,8 @@ app.use(helmet());
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, '../views'));
 
+// Set static files folder
+app.use(express.static(path.join(__dirname, '../../public')));
 
 
 // Setting up sessions (These are stored on the client)

--- a/src/config/vars.js
+++ b/src/config/vars.js
@@ -22,5 +22,7 @@ module.exports = {
 	mongo: {
 		uri: env.NODE_ENV === 'test' ? env.MONGO_URI_TESTS : env.MONGO_URI
 	},
-	logs: env.NODE_ENV === 'production' ? 'combined' : 'dev'
+	logs: env.NODE_ENV === 'production' ? 'combined' : 'dev',
+	STRIPE_SECRET_KEY: env.STRIPE_SECRET_KEY,
+	STRIPE_PUBLISHABLE_KEY: env.STRIPE_PUBLISHABLE_KEY
 }

--- a/src/controller/auth.controller.js
+++ b/src/controller/auth.controller.js
@@ -1,8 +1,6 @@
 const jwt = require('jsonwebtoken');
-const httpStatus = require('http-status');
 const moment = require('moment-timezone');
-const { User } = require('../models');
-const RefreshToken = require('../models/refreshToken.model');
+const { User, RefreshToken } = require('../models/index');
 const {sendEmail, forgotPasswordEmail} = require('../utils/email.utils');
 
 
@@ -16,8 +14,8 @@ exports.registerGET = (req, res, next) => {
 exports.registerPOST = async (req, res, next) => {
   	try {
 		req.body.name = req.body.email.split('@')[0];
-		const user = await new User(req.body).save();
-    	res.status(httpStatus.CREATED).json(user);
+		await new User(req.body).save();
+    	res.redirect('/v1/auth/login');
  	}	 
   	catch (error) {
 		console.log("ERROR: In register user! = ", error.message);

--- a/src/controller/home.controller.js
+++ b/src/controller/home.controller.js
@@ -1,0 +1,14 @@
+const { Item } = require('../models/index');
+
+exports.homeGET = async (req, res, next) => {
+	const items = await Item.find({ $and: [
+		{ ownerId: { $ne: req.user.id } },
+		{ status: 1 }
+	]}, {
+		createdAt: 0,
+		updatedAt: 0,
+		__v: 0
+	});
+
+	res.render('home', {user: req.user, items: items});
+}

--- a/src/controller/item.controller.js
+++ b/src/controller/item.controller.js
@@ -1,0 +1,24 @@
+// const httpStatus = require('http-status');
+const { Item } = require('../models/index');
+const { createStripeEntry } = require('../utils/item.utils');
+
+
+/**
+ * Sell item controller
+ */
+exports.sellGET = (req, res, next) => {
+	res.render('sell', {user: req.user});
+}
+
+exports.sellPOST = async (req, res, next) => {
+	try {
+		req.body.ownerId = req.user.id;
+		const item = await new Item(req.body).save();
+		await createStripeEntry(item);
+		res.redirect('/v1');
+	}
+	catch(err) {
+		console.log("Error in sellPOST controller");
+		throw err;
+	}
+}

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,7 +1,9 @@
 const User = require('./user.model');
 const RefreshToken = require('./refreshToken.model');
+const Item = require('./item.model');
 
 module.exports = {
 	User: User,
 	RefreshToken: RefreshToken,
+	Item: Item
 }

--- a/src/models/item.model.js
+++ b/src/models/item.model.js
@@ -1,0 +1,56 @@
+
+const mongoose = require('mongoose');
+
+
+/**
+ * Item Schema
+ */
+const itemSchema = new mongoose.Schema(
+{
+	name: {
+		type: String,
+		maxlength: 256,
+		required: true,
+		lowercase: true,
+		trim: true
+	},
+	quantity: {
+		type: Number,
+		default: 1,
+	},
+	price: {
+		type: Number,
+		required: true,
+	},
+	condition: {
+		type: Number,
+		default: 3
+	},
+	ownerId: {
+		type: String,
+		index: { background: true },
+		required: true,
+	},
+	status: {
+		type: Number,
+		required: true,
+		default: 1		// 1 -- available, 0 -- sold
+	},
+	priceId: {			// References the stripe Price object
+		type: String,
+		index: true
+	}   
+},
+{
+	timestamps: true,
+	autoIndex: true
+}
+);
+
+
+
+/**
+ * @typedef Item
+ */
+const Item = mongoose.model('Item', itemSchema);
+module.exports = Item;

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -19,7 +19,7 @@ const userSchema = new mongoose.Schema(
 		unique: true,
 		trim: true,
 		lowercase: true,
-		index: { unique: true }
+		index: { unique: true, background: true }
     },
     password: {
 		type: String,
@@ -30,7 +30,6 @@ const userSchema = new mongoose.Schema(
     name: {
 		type: String,
 		maxlength: 128,
-		index: true,
 		trim: true
     },
     services: {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,18 +1,26 @@
 const express = require("express");
 const {verifyJWT} = require('../middlewares/auth');
 const authRoutes = require('./auth.route');
+const itemRoutes = require('./item.route');
+const homeController = require('../controller/home.controller');
 const router = express.Router();
 
+
 /**
- * GET v1/status
+ * GET v1/status (temporary route)
  */
 router.route('/status')
 .get(verifyJWT(), (req, res) => {
 	res.render('status', {user: req.user, account: req.account});
 })
 
+/**
+ * Other routes
+ */
+router.use('/item', itemRoutes);
 router.get('/user', (req, res) => res.send(req.user));
 router.use('/auth', authRoutes);
+router.get('/', verifyJWT(), homeController.homeGET);
 
 
 module.exports = router;

--- a/src/routes/item.route.js
+++ b/src/routes/item.route.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const {validate} = require('express-validation');
+const { sell } = require('../validations/item.validation');
+const {sellGET, sellPOST} = require('../controller/item.controller');
+const {verifyJWT} = require('../middlewares/auth');
+const { STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY } = require('../config/vars');
+const stripe = require('stripe')(STRIPE_SECRET_KEY);
+const  { Item } = require('../models/index');
+
+const router = express.Router();
+
+
+router.get('/sell', verifyJWT(), sellGET);
+router.post('/sell', verifyJWT(), validate(sell), sellPOST);
+
+/**
+ * Payments using stripe
+ */
+router.get('/checkout/:itemId', verifyJWT(), async (req, res) => {
+	console.log("In checkout router...");
+	const item = await Item.findById(req.params.itemId);
+	res.render('checkout', {user: req.user, item: item});
+});
+
+router.get('/retrieve-price/:priceId', verifyJWT(), async (req, res) => {
+	const {priceId} =  req.params ;
+	const price = await stripe.prices.retrieve(priceId);
+
+	res.send({
+	  publicKey: STRIPE_PUBLISHABLE_KEY,
+	  unitAmount: price.unit_amount,
+	  currency: price.currency,
+	});
+});
+
+router.post('/create-checkout-session', verifyJWT(), async (req, res) => {
+	const {quantity, priceId} = req.body;
+
+	const session = await stripe.checkout.sessions.create({
+		payment_method_types: ['card'],
+		mode: 'payment',
+		line_items: [
+		  {
+			price: priceId,
+			quantity: quantity
+		  },
+		],
+		// ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
+		success_url: `https://localhost:3000/v1/status`,	// TODO: redirect to home and notify payment succeeded
+		cancel_url: `https://localhost:3000/v1`,			// TODO: redirect to item checkout page and notify payment failed
+	  });
+	
+	  res.send({
+		sessionId: session.id,
+	  });
+});
+
+
+module.exports = router;

--- a/src/utils/item.utils.js
+++ b/src/utils/item.utils.js
@@ -1,0 +1,29 @@
+const { STRIPE_SECRET_KEY } = require('../config/vars');
+const stripe = require('stripe')(STRIPE_SECRET_KEY);
+
+
+async function createStripeEntry(item) {
+	try {
+		const product = await stripe.products.create({
+			name: item.name
+		});
+		const price = await stripe.prices.create({
+			product: product.id,
+			unit_amount: item.price * 100,	// For converting to rupees (defaults to paisa)
+			currency: 'inr',
+		});
+		item.priceId = price.id;	// Saving the stripe Price obj id to DB
+		await item.save();
+		console.log("Returning from createStripeEntry");
+	}
+	catch(err) {
+		console.log("ERROR: In createStripeEntry. err = ", err.message);
+		throw err;
+	}
+}
+
+
+// EXPORTS
+module.exports = {
+	createStripeEntry,
+}

--- a/src/validations/item.validation.js
+++ b/src/validations/item.validation.js
@@ -1,0 +1,17 @@
+const {Joi} = require("express-validation");
+
+module.exports = {
+	// POST /v1/item/sell
+	sell: {
+		body: Joi.object({
+			name: Joi.string()
+					.required(),
+			quantity: Joi.number()
+						.required(),
+			price: Joi.number()
+					.required(),
+			condition: Joi.number()
+						.required()
+		})
+	},
+};

--- a/src/views/checkout.ejs
+++ b/src/views/checkout.ejs
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Checkout Page</title>
+
+    <!-- Load Stripe.js on your website. -->
+    <script src="https://js.stripe.com/v3/"></script>
+    <script src="/js/client.js" defer></script>
+  </head>
+
+  <body>
+    <div class="sr-root">
+      <div class="sr-main">
+        <header class="sr-header">
+          <div class="sr-header__logo"></div>
+		</header>
+		
+        <section class="container" id=<%= item.priceId %>>
+          <div>
+            <!-- <h1></h1>
+            <h4></h4> -->
+            <div class="pasha-image">
+              <img src="https://picsum.photos/280/320?random=4" width="140" height="160" />
+            </div>
+		  </div>
+		  
+          <div class="quantity-setter">
+            <button class="increment-btn" id="subtract" disabled>
+              -
+            </button>
+            <input type="number" id="quantity-input" min="1" value="1" max=<%= item.quantity %> />
+            <button class="increment-btn" id="add">+</button>
+		  </div>
+		  
+          <p class="sr-legal-text"></p>
+
+          <button id="submit">Buy for <%= item.price %></button>
+		</section>
+		
+        <div id="error-message"></div>
+	  
+	  </div>
+    </div>
+  </body>
+</html>

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -1,0 +1,42 @@
+<% if (!user) { %>
+	<p>Welcome! Please <a href="/v1/auth/login">log in</a>.</p>
+<% } else { %>
+	<h1>Hello, <%= user.name %>.</h1>
+	<p>Check out the listings available and find a steal!</p>
+	<br>
+
+	<% if (items) { %>
+		<div class="item-div">
+			<% for( let i = 0; i < items.length; i++ ) { %>
+				<div class="items" id=<%= items[i].id %> >
+					<h3 class="items-head"><%= items[i].name %> </h3>
+					<p>Qty: <%= items[i].quantity %> </p>
+					<p>Condition: <%= items[i].condition %> </p>
+					<h4>Price: <%= items[i].price %> </p>
+					<% URL = `/v1/item/checkout/${items[i].id}` %> 
+					<a href=<%= URL %>> Buy</a>
+				</div>
+			<% } %>
+		</div>
+	<% } else { %>
+		<h4>No items to display!!!</h4>
+	<% } %>
+
+
+	<% if (!user.services.google) { %>
+		<p>Connect your google account <a href="/v1/auth/connect/google">Connect Google!</a></p>
+	<% } else { %>
+		<p>Disconnect your google account <a href="/v1/auth/disconnect/google">Disconnect Google!</a></p>
+	<% } %>
+	
+	<% if (!user.services.facebook) { %>
+		<p>Connect your facebook account <a href="/v1/auth/connect/facebook">Connect Facebook!</a></p>
+	<% } else { %>
+		<p>Disconnect your facebook account <a href="/v1/auth/disconnect/facebook">Disconnect Facebook!</a></p>
+	<% } %>
+
+	<br>
+	<a href="/v1/auth/logout">Logout</a>
+	
+
+<% } %>

--- a/src/views/sell.ejs
+++ b/src/views/sell.ejs
@@ -1,0 +1,37 @@
+<% if (!user) { %>
+	<p>Welcome! Please <a href="/v1/auth/login">log in</a>.</p>
+<% } else { %>
+	<h1>Hi, <%= user.name %>.</h1>
+	<p>Go ahead and post what you're flipping today 😉.</p>
+	
+	<br>
+
+	<form name="sell" method="POST" action="/v1/item/sell">
+		<table>
+			<tr>
+				<td>Name: </td>
+				<td><input type="text" name="name"></td>
+			</tr>
+			<tr>
+				<td>Quantity: </td>
+				<td><input type="number" name="quantity" min="1"></td>
+			</tr>
+			<tr>
+				<td>Price: INR </td>
+				<td><input type="number" name="price" min="1"></td>
+			</tr>
+			<tr>
+				<td>Condition: </td>
+				<td><input type="number" name="condition" min="1" max="5"></td>
+			</tr>
+
+			<tr>
+			<td colspan="2"><input type="submit" value="Save" ></td>
+			</tr>
+
+		</table>
+	</form>
+
+
+
+<% } %>


### PR DESCRIPTION
- [x] Added ability to post items to sell.
- [x] Items are shown on the home page (created by others).
- [x] Add payments using stripe. Only payments through card are supported as of now.

TODO for payments:
- [x] Adding a webhook for payment success event.
- [ ] Send mail to the buyer if the payment fails. 
- [x] Send mail to both owner and buyer if it succeeds.
- [x] Turning the `availability` status of the `Item` bought to `0`, implying it is sold and not available anymore.
- [x] Add the sold Item to the `Sold` section for the owner and to the `Bought ` section for the buyer. (This could be done by fetching the sold and bought listings for the user instantaneously, no need to save this info).
- [x] Add other modes of payment. (Google pay and Apple pay options are shown on the mobile platforms automatically).
- [ ] Save card details for future transactions.